### PR TITLE
Use Array instead of high level Seq collection

### DIFF
--- a/Ptester.scala
+++ b/Ptester.scala
@@ -10,7 +10,7 @@ object Ptester {
     val arraySizeValues = List[Int] (200, 2000, 20000, 200000, 2000000, 20000000)
     arraySizeValues.foreach( size => {
       val startTime =  java.lang.System.currentTimeMillis()
-      val array = Seq.fill(size)(Random.nextInt)
+      val array = Array.fill(size)(Random.nextInt)
       array.foreach( item => if(item == 2) print("|") )
       val endTime = java.lang.System.currentTimeMillis()
       println(s"Array size: $size time for simple count operation: ${endTime - startTime} in ms")


### PR DESCRIPTION
With the use of Array the drop doesn't seem to be that dramatic anymore. Also the slow operation is the filling of the array. Iterating over it is takes same time both in Java and Scala.